### PR TITLE
World Server Session Token Generation

### DIFF
--- a/Scenes/Authenticate.gd
+++ b/Scenes/Authenticate.gd
@@ -81,7 +81,6 @@ remote func CreateAccount(username, password, player_id):
 		var hashed_password = GenerateHashedPassword(password, salt)
 		PlayerData.dbNewPlayer(username, hashed_password, salt)
 
-	
 	rpc_id(gateway_id, "CreateAccountResults", result, player_id, message)
 
 func GenerateSalt():

--- a/Scenes/Singletons/GameServers.gd
+++ b/Scenes/Singletons/GameServers.gd
@@ -39,5 +39,6 @@ func DistributeLoginToken(token, gameserver):
 	var gameserver_peer_id = gameserverlist[gameserver]
 	rpc_id(gameserver_peer_id, "ReceiveLoginToken", token)
 
-func CreateSessionToken(username):
-	rpc_id(1, "CreateSessionToken", username)
+remote func ReceivePlayerSessionToken(session_token, player_id):
+	print("Player ID: ", session_token)
+	print("Session Token: ", session_token)


### PR DESCRIPTION
## Description

Generate a Session token for the player on the World Server. This is done after the Players login is authenticated on the Authentication Server. The World Server then distributes that Session Token to the client and also the Authentication Server. Currently the Session token prints on both the Client and the Authentication Server.  To make this happen changes have been made on Authentication Server, World Server and Client projects.

The method of making the Session token should probably be changed eventually to something more secure, currently it just takes their player_id, adds to to the currently system time in milli seconds and then runs the sha256 algorithm on it. 

## Motivation
Provide the player a way to authenticate them selves during game play after logging in for things like changing inventory, picking up items etc...

## Testing

Just printing session token on both Authentication Server and Client after logging in.