### PR TITLE
added port randomiser

### DIFF
--- a/addons/port/plugin.cfg
+++ b/addons/port/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="port_randomizer"
+description="this plugin is made to change the network debug port to a random number each time you open godot editor, so it removes the headack of changing  it manualy when you need to debug multiple projects at the same time"
+author="zouhir_dev"
+version="1.0"
+script="port.gd"

--- a/addons/port/port.gd
+++ b/addons/port/port.gd
@@ -1,0 +1,20 @@
+tool
+extends EditorPlugin
+
+
+const RANGE_MIN = 1000
+const RANGE_MAX = 8888
+
+
+func _enter_tree():
+	build()
+
+
+func build():
+	var interface = self.get_editor_interface()
+	var settings = interface.get_editor_settings()
+	randomize()
+	var port = (randi() % RANGE_MAX) + RANGE_MIN
+	settings.set('network/debug/remote_port', port)
+	prints("Port in settings is set to", port)
+	return true

--- a/project.godot
+++ b/project.godot
@@ -23,7 +23,7 @@ Inventory="*res://Inventory.gd"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/godot-sqlite/plugin.cfg", "res://addons/gut/plugin.cfg" )
+enabled=PoolStringArray( "res://addons/godot-sqlite/plugin.cfg", "res://addons/gut/plugin.cfg", "res://addons/port/plugin.cfg" )
 
 [global]
 


### PR DESCRIPTION
## Description

Randomises the port so it two open projects dont conflict with each other

## Motivation

annoying having to manually change port all the time.

## Testing

it works, just sets the debug > network port to random number each time the godot client is opened
