### PR TITLE
Stackable items

### DIFF
--- a/PlayerData.gd
+++ b/PlayerData.gd
@@ -7,7 +7,7 @@ var res
 var res1
 var res2
 var res3
-var db
+var db : MariaDB
 
 func _ready():
 	db = DatabaseConnection.db
@@ -165,3 +165,17 @@ func db_update_inventory(session_token : int, new_inventory : Dictionary):
 	for slot in new_inventory.keys():
 		db.query("INSERT INTO playerinventories (account_id, item_slot, item_id) VALUES (%s, %d, %d );" \
 			% [account_id, slot, new_inventory[slot]["item_id"]])
+
+func db_add_item(id : int, item_name : String, consumable : int, attack : int,
+		defense : int, file_name : String, item_category : int, stack_size : int):
+	var query_s = "INSERT INTO items VALUES (%d, '%s', %d, %d, %d, '%s', %d, %d);" % \
+						[id, item_name, consumable, attack, defense, file_name, item_category, stack_size]
+	var res = db.query(query_s)
+	print(query_s)
+	dbReportError(res)
+	assert(res == OK)
+
+func db_clear_items():
+	var res = db.query("DELETE FROM items;")
+	dbReportError(res)
+	assert(res == OK)

--- a/Scenes/Authenticate.gd
+++ b/Scenes/Authenticate.gd
@@ -9,6 +9,12 @@ var salt
 
 func _ready():
 	OS.set_window_position(Vector2(0,0))
+	
+	# Generate item database
+	$ItemDatabaseGenerator.generate_item_database()
+	# free memory used by the script
+	$ItemDatabaseGenerator.queue_free()
+	
 	StartServer()
 		
 func StartServer():

--- a/Scenes/Authenticate.tscn
+++ b/Scenes/Authenticate.tscn
@@ -1,6 +1,10 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://Scenes/Authenticate.gd" type="Script" id=1]
+[ext_resource path="res://Scenes/ItemDatabaseGenerator.gd" type="Script" id=2]
 
 [node name="Authenticate" type="Node"]
 script = ExtResource( 1 )
+
+[node name="ItemDatabaseGenerator" type="Node" parent="."]
+script = ExtResource( 2 )

--- a/Scenes/ItemDatabaseGenerator.gd
+++ b/Scenes/ItemDatabaseGenerator.gd
@@ -1,0 +1,84 @@
+extends Node
+
+enum { NON_CONSUMABLE = 0, CONSUMABLE}
+enum Category {NOT_EQUIPPABLE = 0, HEAD, CHEST, HANDS, LEGS, FEET, MAIN_HAND, OFF_HAND, RING, AMULET}
+
+# items start from id = 1
+const FIRST_EQUIPPABLE_ITEM_ID = 1
+enum EquippableItemIds { SILVER_HELMET = FIRST_EQUIPPABLE_ITEM_ID,
+						SILVER_CHEST,
+						SILVER_GLOVES,
+						SILVER_LEGGINGS,
+						SILVER_BOOTS,
+						SILVER_SWORD,
+						SILVER_SHIELD,
+						GOLD_RING,
+						DIAMOND_RING,
+						GOLD_AMULET}
+
+# Leave 100000 free ids for equippable items. This is done so that when new items
+# are added we dont need to fix player inventory table
+const FIRST_MATERIAL_ITEM_ID = 100000
+enum MaterialItemIds { COPPER_ORE = FIRST_MATERIAL_ITEM_ID,
+						TIN_ORE,
+						IRON_ORE,
+						COAL,
+						SILVER_ORE,
+						GOLD_ORE}
+
+class Item:
+	var id : int
+	var item_name : String
+	var consumable : int
+	var attack : int
+	var defense : int
+	var file_name : String
+	var item_category : int
+	var stack_size : int
+	func _init(_id, _item_name, _attack, _defense, _item_category, _stack_size = 1, _consumable = NON_CONSUMABLE):
+		id = _id
+		item_name = _item_name
+		consumable = _consumable
+		attack = _attack
+		defense = _defense
+		item_category = _item_category
+		stack_size = _stack_size
+		file_name = str(id) + "_" + _item_name + ".png"
+	static func new_equippable(_id, _attack, _defense, _item_category):
+		var _item_name = (EquippableItemIds.keys()[_id - FIRST_EQUIPPABLE_ITEM_ID] as String).to_lower()
+		return Item.new(_id, _item_name, _attack, _defense, _item_category)
+	static func new_material(_id, _stack_size):
+		var _item_name = (MaterialItemIds.keys()[_id - FIRST_MATERIAL_ITEM_ID] as String).to_lower()
+		return Item.new(_id, _item_name, 0, 0, Category.NOT_EQUIPPABLE, _stack_size)
+	func save():
+		PlayerData.db_add_item(id, item_name, consumable, attack, defense, file_name, item_category, stack_size)
+
+func generate_item_database():
+	PlayerData.db_clear_items()
+	
+	var items = []
+	# Equippable items
+	#                                ID                           ATTACK DEFENSE 	CATEGORY
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_HELMET,	0,		5,	Category.HEAD))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_CHEST,	0,		10,	Category.CHEST))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_GLOVES,	4,		2,	Category.HANDS))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_LEGGINGS,	0,		8,	Category.LEGS))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_BOOTS,	2,		2,	Category.FEET))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_SWORD,	10,		0,	Category.MAIN_HAND))
+	items.append(Item.new_equippable(EquippableItemIds.SILVER_SHIELD,	0,		10,	Category.OFF_HAND))
+	items.append(Item.new_equippable(EquippableItemIds.GOLD_RING,		4,		4,	Category.RING))
+	items.append(Item.new_equippable(EquippableItemIds.DIAMOND_RING,	6,		6,	Category.RING))
+	items.append(Item.new_equippable(EquippableItemIds.GOLD_AMULET,		5,		5,	Category.AMULET))
+	
+	# Materials
+	#                             ID                       stack_size
+	items.append(Item.new_material(MaterialItemIds.COPPER_ORE, 20))
+	items.append(Item.new_material(MaterialItemIds.TIN_ORE, 20))
+	items.append(Item.new_material(MaterialItemIds.IRON_ORE, 20))
+	items.append(Item.new_material(MaterialItemIds.COAL, 40))
+	items.append(Item.new_material(MaterialItemIds.SILVER_ORE, 20))
+	items.append(Item.new_material(MaterialItemIds.GOLD_ORE, 20))
+	
+	# save items into database
+	for item in items:
+		(item as Item).save()

--- a/playerdata.sql
+++ b/playerdata.sql
@@ -13,6 +13,7 @@ CREATE TABLE `items` (
   `defence` int(11) DEFAULT NULL,
   `file_name` varchar(100) DEFAULT NULL,
   `item_category` INT(11) NOT NULL,
+  `stack_size` INT(11) DEFAULT 1,
   PRIMARY KEY (`item_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=LATIN1;
 
@@ -39,17 +40,6 @@ DROP TABLE IF EXISTS `playerinventories`;
 CREATE TABLE `playerinventories` (
   `account_id` int(11) NOT NULL,
   `item_slot` int(11) NOT NULL,
-  `item_id` int(11) DEFAULT NULL
+  `item_id` int(11) DEFAULT NULL,
+  `amount` int(11) DEFAULT 1
 ) ENGINE=InnoDB DEFAULT CHARSET=LATIN1;
-
-INSERT INTO items (item_id, item_name,consumable,attack,defence,file_name,item_category) VALUES
-     (1, 'silver_helmet',0,0,5,'1_silver_helmet.png', 1),
-     (2, 'silver_chest',0,0,10,'2_silver_chest.png',2),
-     (3, 'silver_gloves',0,4,2,'3_silver_gloves.png', 3),
-     (4, 'Silver_leggings',0,0,8,'4_silver_leggings.png',4),
-     (5, 'silver_boots',0,2,2,'5_silver_boots.png',5),
-     (6, 'silver_sword',0,10,0,'6_silver_sword.png',6),
-     (7, 'silver_shield',0,0,10,'7_silver_shield.png',7),
-     (8, 'gold_ring',0,4,4,'8_gold_ring.png',8),
-     (9, 'diamond_ring',0,6,6,'9_diamond_ring.png',8),
-     (10, 'gold_amulet',0,5,5,'10_gold_amulet.png',9);


### PR DESCRIPTION
## Description

 - Added the possibility to hold more than one item per slot
 - Created a new node that is responsible for generating items. Adding a new item is as simple as adding a new ID in the enums and a line in generate_item_database function
 - Added new materials (copper ore, tin ore, iron ore, coal, silver ore, gold ore)

## Motivation

Preparation for crafting

## Testing

Just run the Auth several times. Item db screenshot after generation:

![image](https://user-images.githubusercontent.com/16952886/140297105-7f267593-c549-4e1c-9510-4d6c0f0eaf52.png)


Has no impact on Client (item stacking not implemented yet):
![test17](https://user-images.githubusercontent.com/16952886/140296954-3e819cda-23fa-436f-9235-4ac3bc39e8ae.gif)

