### PR TITLE
Allow WorldServer to query for recipe database

### DIFF
--- a/PlayerData.gd
+++ b/PlayerData.gd
@@ -139,3 +139,22 @@ func db_update_inventory(session_token : int, new_inventory : Dictionary):
 			
 		db.query("INSERT INTO playerinventories (account_id, item_slot, item_id, amount) VALUES (%s, %d, %d, %d );" \
 			% [account_id, slot, new_inventory[slot]["item_id"], amount])
+
+func db_get_recipe_database() -> Dictionary:
+	var res = db.query("SELECT * FROM recipes")
+	var recipe_db = {}
+	# Reconstruct the database as a dictionary with keys being recipe_ids
+	for row in res:
+		var materials_json = JSON.parse(row["materials"]).result
+		var recipe_id = row["recipe_id"]
+		row.erase("materials")
+		row.erase("recipe_id")
+		
+		# make the materials dictionary keys ints. In database the keys are strings
+		var materials = {}
+		for key in materials_json:
+			materials[int(key)] = materials_json[key]
+			
+		row["materials"] = materials
+		recipe_db[recipe_id] = row
+	return recipe_db

--- a/Scenes/Singletons/GameServers.gd
+++ b/Scenes/Singletons/GameServers.gd
@@ -71,3 +71,8 @@ remote func get_username(session_token : int):
 
 func send_username(username : String, session_token : int, world_server_id : int):
 	rpc_id(world_server_id, "store_username", username, session_token)
+
+remote func get_recipe_database():
+	var recipe_db = PlayerData.db_get_recipe_database()
+	var world_server_id = get_tree().get_rpc_sender_id()
+	rpc_id(world_server_id, "receive_recipe_database", recipe_db)


### PR DESCRIPTION
## Description

Added one new function to retrieve recipe database.

## Motivation

WorldServers need to know the crafting recipes

## Testing


Console print on world:

`[WRLD] [main] [20:17:28] [INFO] {0:{materials:{100000:2}, recipe_type:0, required_level:0, result_item_id:100006}, 1:{materials:{100000:1, 100001:1}, recipe_type:0, required_level:0, result_item_id:100007}, 2:{materials:{100002:2, 100003:1}, recipe_type:0, required_level:0, result_item_id:100008}, 3:{materials:{100003:1, 100004:2}, recipe_type:0, required_level:0, result_item_id:100009}, 4:{materials:{100003:1, 100005:2}, recipe_type:0, required_level:0, result_item_id:100010}}`